### PR TITLE
Move options-label back to the right

### DIFF
--- a/lib/find-view.coffee
+++ b/lib/find-view.coffee
@@ -29,7 +29,7 @@ class FindView extends View
         @span class: 'header-item options-label', =>
           @span 'With Options: '
           @span outlet: 'optionsLabel', class: 'options'
-        @a outlet: 'closeButton', class: 'icon icon-x pull-right octicons'
+        @a outlet: 'closeButton', class: 'close-button icon icon-x octicons'
 
       @section class: 'input-block find-container', =>
         @div class: 'input-block-item input-block-item--flex editor-container', =>

--- a/lib/project-find-view.coffee
+++ b/lib/project-find-view.coffee
@@ -43,7 +43,7 @@ class ProjectFindView extends View
         @span class: 'header-item options-label', =>
           @span 'With Options: '
           @span outlet: 'optionsLabel', class: 'options'
-        @a outlet: 'closeButton', class: 'icon icon-x pull-right octicons'
+        @a outlet: 'closeButton', class: 'close-button icon icon-x octicons'
 
       @section outlet: 'replacmentInfoBlock', class: 'input-block', =>
         @progress outlet: 'replacementProgress', class: 'inline-block'

--- a/styles/find-and-replace.less
+++ b/styles/find-and-replace.less
@@ -45,6 +45,7 @@ atom-workspace.find-visible {
   overflow-x: auto;
 
   .header {
+    display: flex;
     padding: @component-padding/4 @component-padding/2;
     min-width: @min-width;
   }
@@ -53,8 +54,8 @@ atom-workspace.find-visible {
     margin-bottom: @component-padding/4;
   }
 
-  .icon-x.pull-right::before{
-    margin: 0;
+  .close-button::before {
+    margin: 0 0 0 @component-padding;
   }
 
   .input-block {
@@ -107,8 +108,10 @@ atom-workspace.find-visible {
   }
 
   .options-label {
-    color: @text-color-subtle;
     position: relative;
+    flex: 1;
+    text-align: right;
+    color: @text-color-subtle;
     .options {
       color: @text-color;
     }


### PR DESCRIPTION
This PR is on top of https://github.com/atom/find-and-replace/pull/687

Initially I thought:

> the x could be confused with clearing the options and not closing the panel.

But having the option labels change right above the buttons is nice because you see what they mean without having to look on the left. So this PR moves them back to the right, sorry for not thinking that through.

![screen shot 2016-05-18 at 4 26 30 pm](https://cloud.githubusercontent.com/assets/378023/15350615/54a35ed0-1d15-11e6-92bc-607f45a20c33.png)
